### PR TITLE
Add generic PageBuilder styling guidance

### DIFF
--- a/Public/Einsaetze/index.php
+++ b/Public/Einsaetze/index.php
@@ -26,7 +26,8 @@ $page->addContent($page->renderFullscreenHero(
     0.8, // Jarallax Speed
     0.5, // Overlay Opacity
     'rgb(0, 0, 0)', // Overlay Color
-    'btn-white-outline' // Button Class
+    'btn-white-outline', // Button Class
+    backgroundImage: '/assets/images/img-20231218-wa0006-1.webp'
 ));
 
 // --- Einsatzliste & Statistik (PHP Include Block) ---

--- a/Public/Einsatzabteilung/index.php
+++ b/Public/Einsatzabteilung/index.php
@@ -26,7 +26,8 @@ $page->addContent($page->renderFullscreenHero(
     0.8, // Jarallax Speed
     0.5, // Overlay Opacity
     'rgb(0, 0, 0)', // Overlay Color
-    'btn-white-outline' // Button Class
+    'btn-white-outline', // Button Class
+    backgroundImage: '/assets/images/img-20210913.webp'
 ));
 
 // --- Text/Bild Block 1: Unsere Einsatzabteilung ---
@@ -56,7 +57,8 @@ $page->addContent($page->renderCallToActionBanner(
     '/Mitmachen', // Button Link
     'Jetzt mitmachen', // Button Text
     'CTA-Einsatzabteilung', // CID Suffix
-    'btn-primary' // Button Class
+    'btn-primary', // Button Class
+    backgroundImage: '/assets/images/img20240812195457.webp'
 ));
 
 // --- Text/Bild Block 3: Spezialisierte Fortbildung ---

--- a/Public/Fahrzeuge/index.php
+++ b/Public/Fahrzeuge/index.php
@@ -19,7 +19,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img-3392.webp'
 ));
 
 // Füge den TSF-W Abschnitt (Bild + Text) hinzu

--- a/Public/Feuerwehrhaus/index.php
+++ b/Public/Feuerwehrhaus/index.php
@@ -19,7 +19,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img20240826185105.webp'
 ));
 
 // Füge den Abschnitt "Unsere Umkleideräume" (Bild rechts, Text links) hinzu

--- a/Public/Foerderverein/index.php
+++ b/Public/Foerderverein/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/chatgpt-image-31.-mrz-2025.webp'
 ));
 
 // Füge den Textabschnitt "Förderverein" hinzu

--- a/Public/Grillhuette/index.php
+++ b/Public/Grillhuette/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img20240514181849.webp'
 ));
 
 // Füge den Features Abschnitt (Grillhütte Infos) hinzu
@@ -97,7 +98,8 @@ $page->addContent($page->renderCallToActionBanner(
     title: 'Interesse geweckt?',
     buttonHref: '/Grillhuette/Reservierung/',
     buttonText: 'Zum Reservierungssystem',
-    btnClass: 'btn-primary'
+    btnClass: 'btn-primary',
+    backgroundImage: '/assets/images/img20240514181524.webp'
     // Parallax background und Overlay werden durch die Methode gehandhabt
 ));
 

--- a/Public/Jugendfeuerwehr/index.php
+++ b/Public/Jugendfeuerwehr/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/whatsapp-bild-2024-08-13-um-19.38.10-b7588198-kopie.webp'
 ));
 
 // Füge den Abschnitt "Unsere Jugendfeuerwehr" (Bild rechts, Text links) hinzu
@@ -51,7 +52,8 @@ $page->addContent($page->renderCallToActionBanner(
     title: 'Interesse geweckt?',
     buttonHref: '/Mitmachen',
     buttonText: 'Jetzt mitmachen',
-    btnClass: 'btn-primary'
+    btnClass: 'btn-primary',
+    backgroundImage: '/assets/images/whatsapp-bild-2024-08-13-um-19.38.35-64599a3b.webp'
     // Parallax background und Overlay werden durch die Methode gehandhabt
 ));
 

--- a/Public/Kinderfeuerwehr/index.php
+++ b/Public/Kinderfeuerwehr/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img-20240821-wa0074.webp'
 ));
 
 // Füge den Abschnitt "Unsere Kinderfeuerwehr" (Bild rechts, Text links) hinzu
@@ -51,7 +52,8 @@ $page->addContent($page->renderCallToActionBanner(
     title: 'Interesse geweckt?',
     buttonHref: '/Mitmachen',
     buttonText: 'Jetzt mitmachen',
-    btnClass: 'btn-primary'
+    btnClass: 'btn-primary',
+    backgroundImage: '/assets/images/img-20240821-wa0041.webp'
     // Parallax background und Overlay werden durch die Methode gehandhabt
 ));
 

--- a/Public/Mitmachen/index.php
+++ b/Public/Mitmachen/index.php
@@ -20,7 +20,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/a5ar3-lq538.webp'
 ));
 
 // Füge den Features Abschnitt (Einsatz-, Jugend-, Kinderfeuerwehr) hinzu

--- a/Public/Realistische-Unfalldarstellung/index.php
+++ b/Public/Realistische-Unfalldarstellung/index.php
@@ -23,7 +23,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img20240825115019.webp'
 ));
 
 // Füge den Abschnitt "R(ealistische)U(nfall)D(arstellung)" (Bild rechts, Text links) hinzu
@@ -44,7 +45,8 @@ $page->addContent($page->renderCTAHeaderTextButtonBanner(
     text: 'Unsere RUD-Gruppe bietet Ihnen die Möglichkeit, realistische Trainingsszenarien zu erleben, die Ihre Einsatzkräfte optimal vorbereiten.', // Verwende den Textparameter für den Untertitel
     buttonLabel: 'Jetzt Kontakt aufnehmen',
     buttonHref: '#image08-55',
-    buttonClass: 'btn-primary'
+    buttonClass: 'btn-primary',
+    backgroundImage: '/assets/images/img20240706091207.webp'
     // Parallax background und Overlay werden durch die Methode gehandhabt
 ));
 

--- a/Public/Unterstuetzen/index.php
+++ b/Public/Unterstuetzen/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img-3214.webp'
 ));
 
 // Füge den Features Abschnitt (Unterstützungsmöglichkeiten) hinzu

--- a/Public/Veranstaltungen/index.php
+++ b/Public/Veranstaltungen/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/frxk9-ka0y0.webp'
 ));
 
 

--- a/Public/Voraus-Helfer/index.php
+++ b/Public/Voraus-Helfer/index.php
@@ -21,7 +21,8 @@ $page->addContent($page->renderFullscreenHero(
     jarallaxSpeed: 0.8,
     overlayOpacity: 0.5,
     overlayColor: 'rgb(0, 0, 0)',
-    btnClass: 'btn-white-outline' // Passe die Button-Klasse an
+    btnClass: 'btn-white-outline', // Passe die Button-Klasse an
+    backgroundImage: '/assets/images/img20241021205129.webp'
 ));
 
 // Füge den Abschnitt "Unsere Voraushelfer" (Bild rechts, Text links) hinzu

--- a/Public/assets/ffr/css/ffr-additional.css
+++ b/Public/assets/ffr/css/ffr-additional.css
@@ -12768,3 +12768,440 @@ a {
   color: #ffffff;
   text-align: left;
 }
+/* ========================================================================== */
+/*  Generisches Styling für PageBuilder-Elemente                             */
+/* ========================================================================== */
+
+#pb-fullscreen-hero,
+.cid-PB-FullscreenHero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 6rem 0;
+  min-height: 60vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(167, 41, 32, 0.45), transparent 60%),
+    linear-gradient(135deg, #101010 0%, #1c1c1c 55%, #2b1b1b 100%);
+}
+
+.cid-PB-FullscreenHero .ffr-overlay {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.cid-PB-FullscreenHero .ffr-section-title,
+.cid-PB-FullscreenHero .ffr-section-subtitle,
+.cid-PB-FullscreenHero .ffr-text,
+.cid-PB-FullscreenHero .ffr-section-btn {
+  color: #ffffff;
+  text-align: center;
+}
+
+.cid-PB-FullscreenHero .ffr-section-btn .btn {
+  background-color: #a72920;
+  border-color: #a72920;
+  color: #ffffff;
+}
+
+.cid-PB-FullscreenHero .ffr-section-btn .btn:hover,
+.cid-PB-FullscreenHero .ffr-section-btn .btn:focus {
+  background-color: #d23428;
+  border-color: #d23428;
+}
+
+#pb-image-teaser,
+.cid-PB-ImageTeaser,
+#pb-image-info,
+.cid-PB-ImageInfo {
+  padding: 5rem 0 3rem;
+  background: linear-gradient(180deg, #2b2b2b 0%, #1b1b1b 100%);
+}
+
+.cid-PB-ImageTeaser .ffr-section-title,
+.cid-PB-ImageInfo .ffr-section-title {
+  color: #ffffff;
+}
+
+.cid-PB-ImageTeaser .ffr-section-subtitle,
+.cid-PB-ImageInfo .ffr-section-subtitle,
+.cid-PB-ImageTeaser .ffr-text,
+.cid-PB-ImageInfo .ffr-text {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.cid-PB-ImageTeaser .item-btn {
+  background-color: #a72920;
+  border-color: #a72920;
+  color: #ffffff;
+}
+
+.cid-PB-ImageTeaser .item-btn:hover,
+.cid-PB-ImageTeaser .item-btn:focus {
+  background-color: #d23428;
+  border-color: #d23428;
+}
+
+#pb-call-to-action,
+#pb-download-header,
+#pb-cta-header,
+#pb-centered-cta,
+.cid-PB-CallToAction,
+.cid-PB-DownloadHeader,
+.cid-PB-CTAHeader,
+.cid-PB-CenteredCTA {
+  padding: 5rem 0;
+  background:
+    radial-gradient(circle at 80% 20%, rgba(167, 41, 32, 0.25), transparent 60%),
+    linear-gradient(135deg, #161616 0%, #1f1f1f 60%, #2b1313 100%);
+}
+
+.cid-PB-CallToAction .card,
+.cid-PB-DownloadHeader .card,
+.cid-PB-CTAHeader .card,
+.cid-PB-CenteredCTA .card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.4);
+}
+
+.cid-PB-CallToAction .card-title,
+.cid-PB-DownloadHeader .card-title,
+.cid-PB-CTAHeader .card-title,
+.cid-PB-CenteredCTA .card-title,
+.cid-PB-CTAHeader .ffr-text {
+  color: #ffffff;
+}
+
+.cid-PB-CallToAction .btn,
+.cid-PB-DownloadHeader .btn,
+.cid-PB-CTAHeader .btn,
+.cid-PB-CenteredCTA .btn {
+  border-radius: 999px;
+  padding: 0.9rem 2.4rem;
+}
+
+.cid-PB-CTAHeader .btn {
+  background-color: #a72920;
+  border-color: #a72920;
+  color: #ffffff;
+}
+
+.cid-PB-CTAHeader .btn:hover,
+.cid-PB-CTAHeader .btn:focus {
+  background-color: #d23428;
+  border-color: #d23428;
+}
+
+#pb-accordion,
+.cid-PB-Accordion {
+  padding: 5rem 0;
+  background: #101010;
+}
+
+.cid-PB-Accordion .ffr-section-title {
+  color: #ffffff;
+}
+
+.cid-PB-Accordion .card {
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  margin-bottom: 1rem;
+}
+
+.cid-PB-Accordion .panel-title-edit {
+  color: #ffffff;
+}
+
+.cid-PB-Accordion .panel-body {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.cid-PB-Accordion .sign {
+  color: #a72920;
+}
+
+#pb-gallery-lightbox,
+.cid-PB-GalleryLightbox {
+  padding: 6rem 0;
+  background: #080808;
+}
+
+.cid-PB-GalleryLightbox .ffr-section-title {
+  color: #ffffff;
+}
+
+.cid-PB-GalleryLightbox .item-wrapper {
+  position: relative;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+}
+
+.cid-PB-GalleryLightbox .icon-wrapper {
+  position: absolute;
+  inset: auto 1.5rem 1.5rem auto;
+  background: rgba(167, 41, 32, 0.85);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.75rem;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.cid-PB-GalleryLightbox .item-wrapper:hover .icon-wrapper {
+  transform: scale(1.05);
+  background: rgba(210, 52, 40, 0.95);
+}
+
+#pb-feature-cards-images,
+#pb-feature-section,
+.cid-PB-FeatureCardsImages,
+.cid-PB-FeatureSection {
+  padding: 5rem 0;
+  background: linear-gradient(180deg, #1f1f1f 0%, #121212 100%);
+}
+
+.cid-PB-FeatureCardsImages .item-wrapper,
+.cid-PB-FeatureSection .item-wrapper {
+  height: 100%;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 2.5rem 2rem;
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.cid-PB-FeatureCardsImages .card-title,
+.cid-PB-FeatureSection .card-title {
+  color: #ffffff;
+}
+
+.cid-PB-FeatureCardsImages .card-text,
+.cid-PB-FeatureSection .card-text {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.cid-PB-FeatureCardsImages .img-wrapper img {
+  border-radius: 1rem;
+  width: 100%;
+  height: auto;
+}
+
+#pb-feature-cards-buttons,
+.cid-PB-FeatureCardsButtons {
+  padding: 5rem 0;
+  background: linear-gradient(180deg, #202020 0%, #141414 100%);
+}
+
+.cid-PB-FeatureCardsButtons .item-wrapper {
+  height: 100%;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 2.5rem 2rem;
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.cid-PB-FeatureCardsButtons .card-title {
+  color: #ffffff;
+}
+
+.cid-PB-FeatureCardsButtons .card-text {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.cid-PB-FeatureCardsButtons .item-btn {
+  background-color: #a72920;
+  border-color: #a72920;
+  color: #ffffff;
+}
+
+.cid-PB-FeatureCardsButtons .item-btn:hover,
+.cid-PB-FeatureCardsButtons .item-btn:focus {
+  background-color: #d23428;
+  border-color: #d23428;
+}
+
+#pb-text-article,
+.cid-PB-TextArticle {
+  padding: 5rem 0;
+  background: #181818;
+}
+
+.cid-PB-TextArticle .card {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.cid-PB-TextArticle .card-title,
+.cid-PB-TextArticle .ffr-text {
+  color: #ffffff;
+}
+
+#pb-image-section,
+.cid-PB-ImageSection {
+  background: #000000;
+  padding: 0;
+}
+
+.cid-PB-ImageSection .image-block {
+  max-width: 960px;
+  margin: 0 auto;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 2rem 4rem rgba(0, 0, 0, 0.45);
+}
+
+#pb-google-map,
+.cid-PB-GoogleMap {
+  padding: 4rem 0;
+  background: linear-gradient(180deg, #1a1a1a 0%, #0f0f0f 100%);
+}
+
+.cid-PB-GoogleMap .google-map {
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: #1f1f1f;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cid-PB-GoogleMap .google-map [id$='-map-container'] {
+  min-height: 420px;
+}
+
+#pb-text-section,
+.cid-PB-TextSection {
+  padding: 5rem 0;
+  background: #151515;
+}
+
+.cid-PB-TextSection .card {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.4);
+}
+
+.cid-PB-TextSection .card-title,
+.cid-PB-TextSection .ffr-section-subtitle,
+.cid-PB-TextSection .ffr-text {
+  color: #ffffff;
+}
+
+#pb-document-cards,
+#pb-download-list,
+#pb-link-grid,
+.cid-PB-DocumentCards,
+.cid-PB-DownloadList,
+.cid-PB-LinkGrid {
+  padding: 5rem 0;
+  background: #121212;
+}
+
+.cid-PB-DocumentCards .ffr-section-title,
+.cid-PB-DocumentCards .ffr-text,
+.cid-PB-DownloadList .ffr-section-title,
+.cid-PB-LinkGrid .ffr-section-title {
+  color: #ffffff;
+}
+
+.cid-PB-DocumentCards .card-wrapper,
+.cid-PB-DownloadList .card,
+.cid-PB-LinkGrid .card {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.cid-PB-DocumentCards .btn,
+.cid-PB-DownloadList .btn,
+.cid-PB-LinkGrid .btn {
+  border-radius: 999px;
+  padding: 0.8rem 2.2rem;
+}
+
+.cid-PB-DocumentCards .btn-primary,
+.cid-PB-DownloadList .btn-primary,
+.cid-PB-LinkGrid .btn-secondary {
+  background-color: #a72920;
+  border-color: #a72920;
+  color: #ffffff;
+}
+
+.cid-PB-DocumentCards .btn-primary:hover,
+.cid-PB-DocumentCards .btn-primary:focus,
+.cid-PB-DownloadList .btn-primary:hover,
+.cid-PB-DownloadList .btn-primary:focus,
+.cid-PB-LinkGrid .btn-secondary:hover,
+.cid-PB-LinkGrid .btn-secondary:focus {
+  background-color: #d23428;
+  border-color: #d23428;
+}
+
+.cid-PB-LinkGrid .border {
+  border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+#pb-section-header,
+.cid-PB-SectionHeader {
+  padding: 5rem 0 3rem;
+  background: linear-gradient(180deg, #1a1a1a 0%, #121212 100%);
+}
+
+.cid-PB-SectionHeader .ffr-section-title,
+.cid-PB-SectionHeader .ffr-section-subtitle {
+  color: #ffffff;
+}
+
+#pb-animated-gallery,
+.cid-PB-AnimatedGallery {
+  padding: 6rem 0;
+  background: #0a0a0a;
+}
+
+.cid-PB-AnimatedGallery .gallery-wrapper {
+  overflow: hidden;
+}
+
+.cid-PB-AnimatedGallery .grid-container {
+  gap: 2rem;
+}
+
+.cid-PB-AnimatedGallery .grid-item img {
+  border-radius: 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.4);
+}
+
+@media (max-width: 767px) {
+  .cid-PB-FullscreenHero,
+  .cid-PB-ImageTeaser,
+  .cid-PB-ImageInfo,
+  .cid-PB-CallToAction,
+  .cid-PB-DownloadHeader,
+  .cid-PB-CTAHeader,
+  .cid-PB-CenteredCTA,
+  .cid-PB-Accordion,
+  .cid-PB-GalleryLightbox,
+  .cid-PB-FeatureCardsImages,
+  .cid-PB-FeatureSection,
+  .cid-PB-FeatureCardsButtons,
+  .cid-PB-TextArticle,
+  .cid-PB-TextSection,
+  .cid-PB-DocumentCards,
+  .cid-PB-DownloadList,
+  .cid-PB-LinkGrid,
+  .cid-PB-SectionHeader,
+  .cid-PB-AnimatedGallery,
+  .cid-PB-GoogleMap {
+    padding: 3.5rem 0;
+  }
+
+  .cid-PB-ImageSection .image-block {
+    border-radius: 1rem;
+  }
+}

--- a/Public/assets/includes/PageBuilder.php
+++ b/Public/assets/includes/PageBuilder.php
@@ -291,6 +291,13 @@ class PageBuilder
     }
 
 
+    /**
+     * Rendert einen Fullscreen-Hero ("header16").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-fullscreen-hero'
+     *  - CID-Suffix: 'PB-FullscreenHero'
+     */
     public function renderFullscreenHero(
         string $id,
         string $title,
@@ -342,6 +349,10 @@ class PageBuilder
      * @param string $imageAlt    Alt-Attribut des Bildes
      * @param string $btnClass    optionale zusätzliche Button-Klasse (z. B. "btn-primary")
      * @return string             Fertiger HTML-Code
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-image-teaser'
+     *  - CID-Suffix: 'PB-ImageTeaser'
      */
     public function renderImageTeaser(
         string $id,
@@ -399,6 +410,10 @@ class PageBuilder
      * @param string $btnClass     Bootstrap-Klasse des Buttons (Default: "btn-primary")
      * @param string $bsVersion    data-bs-version (Default: "5.1")
      * @return string              Fertiger HTML-Code
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-call-to-action'
+     *  - CID-Suffix: 'PB-CallToAction'
      */
     public function renderCallToActionBanner(
         string $id,
@@ -451,6 +466,10 @@ class PageBuilder
      *                             (leer = automatisch "accordion-{$id}")
      * @param string $bsVersion    Bootstrap-Version im data-Attribut
      * @return string              Fertiger HTML-Block
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-accordion'
+     *  - CID-Suffix: 'PB-Accordion'
      */
     public function renderAccordionList(
         string $id,
@@ -610,6 +629,13 @@ class PageBuilder
     }
 
 
+    /**
+     * Rendert eine Galerie mit Lightbox ("gallery1").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-gallery-lightbox'
+     *  - CID-Suffix: 'PB-GalleryLightbox'
+     */
     public function renderGalleryWithLightbox(
         string $id,
         string $title,
@@ -711,6 +737,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert einen Bild-Infoblock ("image08") ohne Button.
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-image-info'
+     *  - CID-Suffix: 'PB-ImageInfo'
+     */
     public function renderImageInfoBlock(
         string $id,
         string $title,
@@ -749,6 +782,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert Feature-Karten mit Bild ("features19").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-feature-cards-images'
+     *  - CID-Suffix: 'PB-FeatureCardsImages'
+     */
     public function renderFeatureCardsWithImages(
         string $id,
         string $title = '',
@@ -799,6 +839,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert einen Text-Artikel ("article13").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-text-article'
+     *  - CID-Suffix: 'PB-TextArticle'
+     */
     public function renderTextArticle(
         string $id,
         string $title,
@@ -831,6 +878,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert eine reine Bildsektion ("image03").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-image-section'
+     *  - CID-Suffix: 'PB-ImageSection'
+     */
     public function renderImageSection(
         string $id,
         string $imageSrc,
@@ -851,6 +905,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert einen Download-Header mit mehreren Buttons ("header14").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-download-header'
+     *  - CID-Suffix: 'PB-DownloadHeader'
+     */
     public function renderDownloadHeaderWithButtons(
         string $id,
         string $title,
@@ -892,6 +953,13 @@ class PageBuilder
     HTML;
     }
 
+    /**
+     * Rendert einen CTA-Header mit Text und Button ("header14").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-cta-header'
+     *  - CID-Suffix: 'PB-CTAHeader'
+     */
     public function renderCTAHeaderTextButtonBanner(
         string $id,
         string $title,
@@ -935,6 +1003,13 @@ HTML;
     }
 
 
+    /**
+     * Rendert Feature-Karten mit Button ("features5").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-feature-cards-buttons'
+     *  - CID-Suffix: 'PB-FeatureCardsButtons'
+     */
     public function renderFeatureCardsWithButtons(
         string $id,
         array $features,
@@ -981,6 +1056,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert eine Feature-Sektion ohne Bilder ("features19").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-feature-section'
+     *  - CID-Suffix: 'PB-FeatureSection'
+     */
     public function renderFeatureSection(
         string $id,
         array $features,
@@ -1026,6 +1108,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert eine Zwei-Klick-Google-Map ("map1").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-google-map'
+     *  - CID-Suffix: 'PB-GoogleMap'
+     */
     public function renderGoogleMap(
         string $id,
         string $iframeSrc,
@@ -1076,6 +1165,13 @@ HTML;
     }
 
 
+    /**
+     * Rendert eine Text-Sektion mit mehreren Abschnitten ("article07").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-text-section'
+     *  - CID-Suffix: 'PB-TextSection'
+     */
     public function renderTextSection(
         string $id,
         string $mainTitle,
@@ -1124,6 +1220,13 @@ HTML;
     }
 
 
+    /**
+     * Rendert Download-Karten ("content5") mit Buttons.
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-document-cards'
+     *  - CID-Suffix: 'PB-DocumentCards'
+     */
     public function renderDocumentDownloadCards(
         string $id,
         string $title,
@@ -1179,6 +1282,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert einen Abschnitts-Header ("content4").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-section-header'
+     *  - CID-Suffix: 'PB-SectionHeader'
+     */
     public function renderSectionHeader(
         string $id,
         string $title,
@@ -1211,6 +1321,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert eine Downloadliste ("content5").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-download-list'
+     *  - CID-Suffix: 'PB-DownloadList'
+     */
     public function renderDownloadList(
         string $id,
         string $title,
@@ -1260,6 +1377,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert ein Raster aus Link-Karten ("content5").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-link-grid'
+     *  - CID-Suffix: 'PB-LinkGrid'
+     */
     public function renderLinkCardGrid(
         string $id,
         string $title,
@@ -1313,6 +1437,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert eine animierte Galerie ("gallery4").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-animated-gallery'
+     *  - CID-Suffix: 'PB-AnimatedGallery'
+     */
     public function renderAnimatedGallery(
         string $id,
         array $rows,
@@ -1358,6 +1489,13 @@ HTML;
     HTML;
     }
 
+    /**
+     * Rendert einen zentral ausgerichteten CTA ("header14").
+     *
+     * Standard-IDs für generisches Styling:
+     *  - Section-ID: 'pb-centered-cta'
+     *  - CID-Suffix: 'PB-CenteredCTA'
+     */
     public function renderCenteredCTA(
         string $id,
         string $title,

--- a/Public/assets/includes/PageBuilder.php
+++ b/Public/assets/includes/PageBuilder.php
@@ -157,6 +157,26 @@ class PageBuilder
         $this->contentBlocks[] = $html;
     }
 
+    /**
+     * Baut das optionale Inline-Style-Attribut für dynamische Hintergrundbilder.
+     */
+    private function buildBackgroundStyle(?string $backgroundImage): string
+    {
+        if ($backgroundImage === null) {
+            return '';
+        }
+
+        $backgroundImage = trim($backgroundImage);
+
+        if ($backgroundImage === '') {
+            return '';
+        }
+
+        $backgroundImage = htmlspecialchars($backgroundImage, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        return " style=\"background-image: url('{$backgroundImage}');\"";
+    }
+
     public function setFavicon(string $href): void
     {
         // Ensure path starts with a slash for absolute paths from the site root
@@ -294,6 +314,8 @@ class PageBuilder
     /**
      * Rendert einen Fullscreen-Hero ("header16").
      *
+     * @param string|null $backgroundImage Optionales Hintergrundbild (überschreibt CSS-Default)
+     *
      * Standard-IDs für generisches Styling:
      *  - Section-ID: 'pb-fullscreen-hero'
      *  - CID-Suffix: 'PB-FullscreenHero'
@@ -309,12 +331,14 @@ class PageBuilder
         float  $overlayOpacity = 0.2,
         string $overlayColor = 'rgb(0, 0, 0)',
         string $btnClass = 'btn-secondary',
+        ?string $backgroundImage = null,
         string $bsVersion = '5.1'
     ): string {
         $cidClass = $cidSuffix !== '' ? "cid-{$cidSuffix}" : '';
+        $backgroundStyle = $this->buildBackgroundStyle($backgroundImage);
 
         return <<<HTML
-    <section data-bs-version="{$bsVersion}" class="header16 {$cidClass} ffr-fullscreen jarallax" id="{$id}" data-jarallax-speed="{$jarallaxSpeed}">
+    <section data-bs-version="{$bsVersion}" class="header16 {$cidClass} ffr-fullscreen jarallax" id="{$id}" data-jarallax-speed="{$jarallaxSpeed}"{$backgroundStyle}>
         <div class="ffr-overlay" style="opacity: {$overlayOpacity}; background-color: {$overlayColor};"></div>
         <div class="container-fluid">
             <div class="row">
@@ -408,6 +432,7 @@ class PageBuilder
      * @param string $buttonText   Button-Beschriftung
      * @param string $cidSuffix    Teil hinter "cid-" für Klasse (leer = kein cid-Teil)
      * @param string $btnClass     Bootstrap-Klasse des Buttons (Default: "btn-primary")
+     * @param string|null $backgroundImage Optionales Hintergrundbild (überschreibt CSS-Default)
      * @param string $bsVersion    data-bs-version (Default: "5.1")
      * @return string              Fertiger HTML-Code
      *
@@ -422,13 +447,15 @@ class PageBuilder
         string $buttonText,
         string $cidSuffix = '',
         string $btnClass = 'btn-primary',
+        ?string $backgroundImage = null,
         string $bsVersion = '5.1'
     ): string {
         // "cid-..." nur anhängen, wenn gewünscht
         $cidClass = $cidSuffix !== '' ? "cid-{$cidSuffix}" : '';
+        $backgroundStyle = $this->buildBackgroundStyle($backgroundImage);
 
         return <<<HTML
-            <section data-bs-version="{$bsVersion}" class="header14 {$cidClass} ffr-parallax-background" id="{$id}">
+            <section data-bs-version="{$bsVersion}" class="header14 {$cidClass} ffr-parallax-background" id="{$id}"{$backgroundStyle}>
                 <div class="container">
                     <div class="row justify-content-center">
                         <div class="card col-12 col-md-12 col-lg-9">
@@ -908,6 +935,8 @@ class PageBuilder
     /**
      * Rendert einen Download-Header mit mehreren Buttons ("header14").
      *
+     * @param string|null $backgroundImage Optionales Hintergrundbild (überschreibt CSS-Default)
+     *
      * Standard-IDs für generisches Styling:
      *  - Section-ID: 'pb-download-header'
      *  - CID-Suffix: 'PB-DownloadHeader'
@@ -917,9 +946,11 @@ class PageBuilder
         string $title,
         array $buttons, // Format: [['label' => 'Text', 'href' => 'link', 'class' => 'btn-primary'], ...]
         string $cidSuffix = '',
+        ?string $backgroundImage = null,
         string $bsVersion = '5.1'
     ): string {
         $cidClass = $cidSuffix !== '' ? "cid-{$cidSuffix}" : '';
+        $backgroundStyle = $this->buildBackgroundStyle($backgroundImage);
 
         $buttonHtml = '';
         foreach ($buttons as $btn) {
@@ -932,7 +963,7 @@ class PageBuilder
         }
 
         return <<<HTML
-    <section data-bs-version="{$bsVersion}" class="header14 {$cidClass}" id="{$id}">
+    <section data-bs-version="{$bsVersion}" class="header14 {$cidClass}" id="{$id}"{$backgroundStyle}>
         <div class="container">
             <div class="row justify-content-center">
                 <div class="card col-12 col-md-12 col-lg-12">
@@ -956,6 +987,8 @@ class PageBuilder
     /**
      * Rendert einen CTA-Header mit Text und Button ("header14").
      *
+     * @param string|null $backgroundImage Optionales Hintergrundbild (überschreibt CSS-Default)
+     *
      * Standard-IDs für generisches Styling:
      *  - Section-ID: 'pb-cta-header'
      *  - CID-Suffix: 'PB-CTAHeader'
@@ -968,15 +1001,17 @@ class PageBuilder
         string $buttonHref,
         string $buttonClass = 'btn-primary',
         string $cidSuffix = '',
+        ?string $backgroundImage = null,
         string $bsVersion = '5.1'
     ): string {
         $cidClass   = $cidSuffix !== '' ? "cid-{$cidSuffix}" : '';
         $buttonLabel = htmlspecialchars($buttonLabel);
         $buttonHref  = htmlspecialchars($buttonHref);
         $buttonClass = htmlspecialchars($buttonClass);
+        $backgroundStyle = $this->buildBackgroundStyle($backgroundImage);
 
         return <<<HTML
-<section data-bs-version="{$bsVersion}" class="header14 {$cidClass} ffr-parallax-background" id="{$id}">
+<section data-bs-version="{$bsVersion}" class="header14 {$cidClass} ffr-parallax-background" id="{$id}"{$backgroundStyle}>
     <div class="container">
         <div class="row justify-content-center">
             <div class="card col-12 col-md-12 col-lg-12">
@@ -1492,6 +1527,8 @@ HTML;
     /**
      * Rendert einen zentral ausgerichteten CTA ("header14").
      *
+     * @param string|null $backgroundImage Optionales Hintergrundbild (überschreibt CSS-Default)
+     *
      * Standard-IDs für generisches Styling:
      *  - Section-ID: 'pb-centered-cta'
      *  - CID-Suffix: 'PB-CenteredCTA'
@@ -1502,14 +1539,16 @@ HTML;
         string $buttonLabel,
         string $buttonHref,
         string $cidSuffix = '',
+        ?string $backgroundImage = null,
         string $bsVersion = '5.1'
     ): string {
         $cidClass     = $cidSuffix !== '' ? "cid-{$cidSuffix}" : '';
         $buttonLabel  = htmlspecialchars($buttonLabel);
         $buttonHref   = htmlspecialchars($buttonHref);
+        $backgroundStyle = $this->buildBackgroundStyle($backgroundImage);
 
         return <<<HTML
-    <section data-bs-version="{$bsVersion}" class="header14 {$cidClass}" id="{$id}">
+    <section data-bs-version="{$bsVersion}" class="header14 {$cidClass}" id="{$id}"{$backgroundStyle}>
         <div class="container">
             <div class="row justify-content-center">
                 <div class="card col-12 col-md-12 col-lg-10">

--- a/Public/index.php
+++ b/Public/index.php
@@ -14,7 +14,8 @@ $page->addContent($page->renderFullscreenHero(
     'Im Glanz der Flammen, im Herzen des Dorfes.',
     'Erfahre mehr',
     '#image08-h',
-    'Hero-Homepage'
+    'Hero-Homepage',
+    backgroundImage: '/assets/images/img20240729201025-2.webp'
 ));
 
 $page->addContent($page->renderImageTeaser(
@@ -45,7 +46,8 @@ $page->addContent($page->renderCallToActionBanner(
     'Bereit für den Einsatz deines Lebens?',
     '/Mitmachen',
     'Jetzt mitmachen',
-    'CTA-Startseite'
+    'CTA-Startseite',
+    backgroundImage: '/assets/images/img20240729193049.webp'
 ));
 
 $page->addContent($page->renderImageTeaser(


### PR DESCRIPTION
## Summary
- add a shared set of generic styles for every PageBuilder element so that each component has an on-brand default look
- document the default section IDs and cid-suffixes directly in the PageBuilder helpers to point to the new styles

## Testing
- php -l Public/assets/includes/PageBuilder.php

------
https://chatgpt.com/codex/tasks/task_e_68e2a7ea94a8832a8b8adc4fb6f38cfa