### PR TITLE
Jahresplan: html2canvas export fallback and error handling

### DIFF
--- a/Public/Verwaltung/Jahresplan/script.js
+++ b/Public/Verwaltung/Jahresplan/script.js
@@ -979,14 +979,36 @@ function getExportCanvas() {
         return null;
     }
 
-    const renderPromise = window.html2canvas(element, { scale: 2 });
-    if (!renderPromise || typeof renderPromise.then !== 'function') {
-        console.error('html2canvas hat kein Promise zurückgegeben.');
+    let legacyResolve;
+    const legacyPromise = new Promise(resolve => {
+        legacyResolve = resolve;
+    });
+    const options = { scale: 2, onrendered: legacyResolve };
+
+    let renderResult;
+    try {
+        renderResult = window.html2canvas(element, options);
+    } catch (error) {
+        console.error('html2canvas konnte nicht ausgeführt werden.', error);
         alert('Export konnte nicht gestartet werden. Bitte laden Sie die Seite neu.');
         return null;
     }
 
-    return renderPromise;
+    if (renderResult instanceof HTMLCanvasElement) {
+        return Promise.resolve(renderResult);
+    }
+
+    if (renderResult && typeof renderResult.then === 'function') {
+        return renderResult;
+    }
+
+    if (renderResult === undefined) {
+        return legacyPromise;
+    }
+
+    console.error('html2canvas hat kein Promise zurückgegeben.');
+    alert('Export konnte nicht gestartet werden. Bitte laden Sie die Seite neu.');
+    return null;
 }
 
 function exportPng() {


### PR DESCRIPTION
### Motivation
- Exports (PNG/PDF) failed when `html2canvas` did not return a Promise (legacy versions or different return types), causing user-facing alerts and blocked exports.

### Description
- Updated `getExportCanvas` in `Public/Verwaltung/Jahresplan/script.js` to add a legacy callback fallback using an `onrendered` handler and a `legacyPromise`.
- Added handling for synchronous `HTMLCanvasElement` returns, Promise returns, `undefined` (legacy callback-only) returns, and runtime exceptions from `window.html2canvas`.
- Retained console error messages and user alerts and return `null` when the export cannot be started.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f22a40cc832abac07e0a447a711b)